### PR TITLE
Convert to hashicorp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+# Caution:
+
+The purpose of this fork is ensure stability in 
+[Terraform](https://github.com/hashicorp/terraform) while the upstream 
+library at github.com/awslabs/aws-sdk-go continues it's internal refactor.  
+
+You probably do not want to use this fork. 
+
 # AWS SDK for Go
 
 [![GoDoc](http://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/awslabs/aws-sdk-go)

--- a/aws/doc.go
+++ b/aws/doc.go
@@ -1,3 +1,3 @@
 // Package aws contains support code for the various AWS clients in the
-// github.com/awslabs/aws-sdk-go/gen subpackages.
+// github.com/hashicorp/aws-sdk-go/gen subpackages.
 package aws

--- a/aws/ec2_test.go
+++ b/aws/ec2_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/aws"
 )
 
 func TestEC2Request(t *testing.T) {

--- a/aws/json_test.go
+++ b/aws/json_test.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/aws"
 )
 
 func TestJSONRequest(t *testing.T) {

--- a/aws/query_test.go
+++ b/aws/query_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/aws"
 )
 
 func TestQueryRequest(t *testing.T) {

--- a/aws/rest_test.go
+++ b/aws/rest_test.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/aws"
 )
 
 func TestRestRequest(t *testing.T) {

--- a/aws/types_test.go
+++ b/aws/types_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/aws"
 )
 
 func TestUnixTimestampSerialization(t *testing.T) {

--- a/aws/xml_test.go
+++ b/aws/xml_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/xml"
 	"testing"
 
-	"github.com/awslabs/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/aws"
 )
 
 type XMLRequest struct {

--- a/cmd/aws-gen-gocli/aws-gen-gocli.go
+++ b/cmd/aws-gen-gocli/aws-gen-gocli.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/awslabs/aws-sdk-go/model"
+	"github.com/hashicorp/aws-sdk-go/model"
 )
 
 func main() {

--- a/cmd/aws-gen-goendpoints/aws-gen-goendpoints.go
+++ b/cmd/aws-gen-goendpoints/aws-gen-goendpoints.go
@@ -7,7 +7,7 @@ package main
 import (
 	"os"
 
-	"github.com/awslabs/aws-sdk-go/model"
+	"github.com/hashicorp/aws-sdk-go/model"
 )
 
 func main() {

--- a/gen/autoscaling/autoscaling.go
+++ b/gen/autoscaling/autoscaling.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/cloudformation/cloudformation.go
+++ b/gen/cloudformation/cloudformation.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/cloudfront/cloudfront.go
+++ b/gen/cloudfront/cloudfront.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/cloudhsm/cloudhsm.go
+++ b/gen/cloudhsm/cloudhsm.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 // CloudHSM is a client for Amazon CloudHSM.

--- a/gen/cloudsearch/cloudsearch.go
+++ b/gen/cloudsearch/cloudsearch.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/cloudsearchdomain/cloudsearchdomain.go
+++ b/gen/cloudsearchdomain/cloudsearchdomain.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/cloudtrail/cloudtrail.go
+++ b/gen/cloudtrail/cloudtrail.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 // CloudTrail is a client for AWS CloudTrail.

--- a/gen/cloudwatch/cloudwatch.go
+++ b/gen/cloudwatch/cloudwatch.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/codedeploy/codedeploy.go
+++ b/gen/codedeploy/codedeploy.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 // CodeDeploy is a client for AWS CodeDeploy.

--- a/gen/cognito/identity/identity.go
+++ b/gen/cognito/identity/identity.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 // CognitoIdentity is a client for Amazon Cognito Identity.

--- a/gen/cognito/sync/sync.go
+++ b/gen/cognito/sync/sync.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/config/config.go
+++ b/gen/config/config.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 // Config is a client for AWS Config.

--- a/gen/datapipeline/datapipeline.go
+++ b/gen/datapipeline/datapipeline.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 // DataPipeline is a client for AWS Data Pipeline.

--- a/gen/directconnect/directconnect.go
+++ b/gen/directconnect/directconnect.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 // DirectConnect is a client for AWS Direct Connect.

--- a/gen/dynamodb/dynamodb.go
+++ b/gen/dynamodb/dynamodb.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 // DynamoDB is a client for Amazon DynamoDB.

--- a/gen/ec2/ec2.go
+++ b/gen/ec2/ec2.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 // EC2 is a client for Amazon Elastic Compute Cloud.

--- a/gen/ecs/ecs.go
+++ b/gen/ecs/ecs.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/elasticache/elasticache.go
+++ b/gen/elasticache/elasticache.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/elasticbeanstalk/elasticbeanstalk.go
+++ b/gen/elasticbeanstalk/elasticbeanstalk.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/elastictranscoder/elastictranscoder.go
+++ b/gen/elastictranscoder/elastictranscoder.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/elb/elb.go
+++ b/gen/elb/elb.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/emr/emr.go
+++ b/gen/emr/emr.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 // EMR is a client for Amazon Elastic MapReduce.

--- a/gen/glacier/glacier.go
+++ b/gen/glacier/glacier.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/iam/iam.go
+++ b/gen/iam/iam.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/importexport/importexport.go
+++ b/gen/importexport/importexport.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/kinesis/kinesis.go
+++ b/gen/kinesis/kinesis.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 // Kinesis is a client for Amazon Kinesis.

--- a/gen/kms/kms.go
+++ b/gen/kms/kms.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 // KMS is a client for AWS Key Management Service.

--- a/gen/lambda/lambda.go
+++ b/gen/lambda/lambda.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/logs/logs.go
+++ b/gen/logs/logs.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 // Logs is a client for Amazon CloudWatch Logs.

--- a/gen/opsworks/opsworks.go
+++ b/gen/opsworks/opsworks.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 // OpsWorks is a client for AWS OpsWorks.

--- a/gen/rds/rds.go
+++ b/gen/rds/rds.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/redshift/redshift.go
+++ b/gen/redshift/redshift.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/route53/route53.go
+++ b/gen/route53/route53.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/route53domains/route53domains.go
+++ b/gen/route53domains/route53domains.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 // Route53Domains is a client for Amazon Route 53 Domains.

--- a/gen/s3/s3.go
+++ b/gen/s3/s3.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/sdb/sdb.go
+++ b/gen/sdb/sdb.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/ses/ses.go
+++ b/gen/ses/ses.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/sns/sns.go
+++ b/gen/sns/sns.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/sqs/sqs.go
+++ b/gen/sqs/sqs.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/storagegateway/storagegateway.go
+++ b/gen/storagegateway/storagegateway.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 // StorageGateway is a client for AWS Storage Gateway.

--- a/gen/sts/sts.go
+++ b/gen/sts/sts.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 import (

--- a/gen/support/support.go
+++ b/gen/support/support.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 // Support is a client for AWS Support.

--- a/gen/swf/swf.go
+++ b/gen/swf/swf.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/endpoints"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 // SWF is a client for Amazon Simple Workflow Service.

--- a/internal/route53_serialization_test.go
+++ b/internal/route53_serialization_test.go
@@ -4,8 +4,8 @@ import (
 	"encoding/xml"
 	"testing"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/route53"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/route53"
 )
 
 func TestRoute53RequestSerialization(t *testing.T) {

--- a/internal/unmarshal_xml_test.go
+++ b/internal/unmarshal_xml_test.go
@@ -5,9 +5,9 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/awslabs/aws-sdk-go/aws"
-	"github.com/awslabs/aws-sdk-go/gen/iam"
-	"github.com/awslabs/aws-sdk-go/gen/sqs"
+	"github.com/hashicorp/aws-sdk-go/aws"
+	"github.com/hashicorp/aws-sdk-go/gen/iam"
+	"github.com/hashicorp/aws-sdk-go/gen/sqs"
 )
 
 func Test_SQSUnmarshalXML(t *testing.T) {

--- a/model/templates.go
+++ b/model/templates.go
@@ -48,8 +48,8 @@ import (
   "net/http"
   "time"
 
-  "github.com/awslabs/aws-sdk-go/aws"
-  "github.com/awslabs/aws-sdk-go/gen/endpoints"
+  "github.com/hashicorp/aws-sdk-go/aws"
+  "github.com/hashicorp/aws-sdk-go/gen/endpoints"
 )
 
 {{ end }}


### PR DESCRIPTION
In order to use this in Terraform, we need to find/replace awslabs with hashicorp, then run `make` to regenerate and install things :cry:

The purpose of this PR and fork is solely to gain stability while the upstream github.com/awslabs/aws-sdk-go library continues it's internal refactor.