### PR TITLE
Fix InternetGatewayIDs XML element

### DIFF
--- a/gen/ec2/ec2.go
+++ b/gen/ec2/ec2.go
@@ -3166,7 +3166,7 @@ type DescribeInstancesResult struct {
 type DescribeInternetGatewaysRequest struct {
 	DryRun             aws.BooleanValue `ec2:"DryRun" xml:"dryRun"`
 	Filters            []Filter         `ec2:"Filter" xml:"Filter>Filter"`
-	InternetGatewayIDs []string         `ec2:"InternetGatewayIds" xml:"internetGatewayId>item"`
+	InternetGatewayIDs []string         `ec2:"InternetGatewayId" xml:"internetGatewayId>item"`
 }
 
 // DescribeInternetGatewaysResult is undocumented.


### PR DESCRIPTION
This PR changes the XML element in `gen/ec2/ec2.go`, `DescribeInternetGatewaysRequest` struct which is blocking hashicorp/terraform/pull/1113. 

The risk here is diverging from https://github.com/awslabs/aws-sdk-go and applying patches, but it can unblock us in our migration efforts (`key-pair` is also blocked on a bug, see https://github.com/awslabs/aws-sdk-go/issues/110). 

I think it's worth diverging. When the all mighty `develop` branch gets merged into https://github.com/awslabs/aws-sdk-go, there will be some degree of chaos anyway, and we'll be running all our acceptance tests then and will either have this fixed, or it will pop up again and we can send a PR when they're back to accepting patches.