### PR TITLE
Apply patch from https://github.com/awslabs/aws-sdk-go/issues/110#issuec...

### DIFF
--- a/aws/ec2.go
+++ b/aws/ec2.go
@@ -95,7 +95,10 @@ func (c *EC2Client) loadValues(v url.Values, i interface{}, prefix string) error
 	for value.Kind() == reflect.Ptr {
 		value = value.Elem()
 	}
-
+	if casted, ok := value.Interface().([]byte); ok && prefix != "" {
+		v.Set(prefix, string(casted))
+		return nil
+	}
 	if value.Kind() == reflect.Slice {
 		for i := 0; i < value.Len(); i++ {
 			vPrefix := prefix


### PR DESCRIPTION
Apply patch from https://github.com/awslabs/aws-sdk-go/issues/110#issuecomment-75593747

This patch fixes a panic in the aws-sdk-go library for importing a keypair, maybe other things too.

