### PR TITLE
Fix IPPermissions mapping for Groups

### DIFF
--- a/gen/ec2/ec2.go
+++ b/gen/ec2/ec2.go
@@ -4281,7 +4281,7 @@ type IPPermission struct {
 	IPProtocol       aws.StringValue   `ec2:"IpProtocol" xml:"ipProtocol"`
 	IPRanges         []IPRange         `ec2:"IpRanges" xml:"ipRanges>item"`
 	ToPort           aws.IntegerValue  `ec2:"ToPort" xml:"toPort"`
-	UserIDGroupPairs []UserIDGroupPair `ec2:"UserIdGroupPairs" xml:"groups>item"`
+	UserIDGroupPairs []UserIDGroupPair `ec2:"Groups" xml:"groups>item"`
 }
 
 // IPRange is undocumented.


### PR DESCRIPTION
The XML definition in ec2 is incorrectly `UserIdGroupPairs`, should be `Groups`. 

Tracked also at https://github.com/awslabs/aws-sdk-go/issues/116